### PR TITLE
Restore video_player package versions

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,6 +1,15 @@
 ## NEXT
 
+## 2.11.1
+
+* Points federated implementation dependencies to the yamacrypt/flutter_packages
+  Git repository.
+
+## 2.11.0
+
 * Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
+* Adds an `initialBitrate` option on `VideoPlayerOptions` to provide adaptive
+  streaming bandwidth hints on Android and iOS implementations.
 
 ## 2.10.0
 

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -444,6 +444,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           uri: dataSource,
           formatHint: formatHint,
           httpHeaders: httpHeaders,
+          initialBitrate: videoPlayerOptions?.initialBitrate,
         );
       case DataSourceType.file:
         dataSourceDescription = DataSource(

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -25,9 +25,21 @@ dependencies:
   flutter:
     sdk: flutter
   html: ^0.15.0
-  video_player_android: ^2.8.1
-  video_player_avfoundation: ^2.7.0
-  video_player_platform_interface: ^6.3.0
+  video_player_android:
+    git:
+      url: https://github.com/yamacrypt/flutter_packages.git
+      ref: main
+      path: packages/video_player/video_player_android
+  video_player_avfoundation:
+    git:
+      url: https://github.com/yamacrypt/flutter_packages.git
+      ref: main
+      path: packages/video_player/video_player_avfoundation
+  video_player_platform_interface:
+    git:
+      url: https://github.com/yamacrypt/flutter_packages.git
+      ref: main
+      path: packages/video_player/video_player_platform_interface
   video_player_web: ^2.1.0
 
 dev_dependencies:

--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.9.1
+
+* Uses the yamacrypt/flutter_packages Git repository for the platform
+  interface dependency when consumed via git.
+
+## 2.9.0
+
+* Adds support for specifying an initial bandwidth estimate for adaptive
+  network streams.
+
 ## 2.8.13
 
 * Bumps com.android.tools.build:gradle to 8.12.1.

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/HttpVideoAsset.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/HttpVideoAsset.java
@@ -15,6 +15,7 @@ import androidx.media3.common.util.UnstableApi;
 import androidx.media3.datasource.DataSource;
 import androidx.media3.datasource.DefaultDataSource;
 import androidx.media3.datasource.DefaultHttpDataSource;
+import androidx.media3.datasource.TransferListener;
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
 import androidx.media3.exoplayer.source.MediaSource;
 import java.util.Map;
@@ -23,16 +24,19 @@ final class HttpVideoAsset extends VideoAsset {
   @NonNull private final StreamingFormat streamingFormat;
   @NonNull private final Map<String, String> httpHeaders;
   @Nullable private final String userAgent;
+  @Nullable private final Long initialBitrate;
 
   HttpVideoAsset(
       @Nullable String assetUrl,
       @NonNull StreamingFormat streamingFormat,
       @NonNull Map<String, String> httpHeaders,
-      @Nullable String userAgent) {
+      @Nullable String userAgent,
+      @Nullable Long initialBitrate) {
     super(assetUrl);
     this.streamingFormat = streamingFormat;
     this.httpHeaders = httpHeaders;
     this.userAgent = userAgent;
+    this.initialBitrate = initialBitrate;
   }
 
   @NonNull
@@ -76,8 +80,18 @@ final class HttpVideoAsset extends VideoAsset {
   MediaSource.Factory getMediaSourceFactory(
       Context context, DefaultHttpDataSource.Factory initialFactory) {
     unstableUpdateDataSourceFactory(initialFactory, httpHeaders, userAgent);
+    TransferListener transferListener = getTransferListener();
+    if (transferListener != null) {
+      initialFactory.setTransferListener(transferListener);
+    }
     DataSource.Factory dataSourceFactory = new DefaultDataSource.Factory(context, initialFactory);
     return new DefaultMediaSourceFactory(context).setDataSourceFactory(dataSourceFactory);
+  }
+
+  @Override
+  @Nullable
+  public Long getInitialBitrate() {
+    return initialBitrate;
   }
 
   // TODO: Migrate to stable API, see https://github.com/flutter/flutter/issues/147039.

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
@@ -220,6 +220,16 @@ public class Messages {
       this.viewType = setterArg;
     }
 
+    private @Nullable Long initialBitrate;
+
+    public @Nullable Long getInitialBitrate() {
+      return initialBitrate;
+    }
+
+    public void setInitialBitrate(@Nullable Long setterArg) {
+      this.initialBitrate = setterArg;
+    }
+
     /** Constructor is non-public to enforce null safety; use Builder. */
     CreateMessage() {}
 
@@ -236,12 +246,13 @@ public class Messages {
           && Objects.equals(formatHint, that.formatHint)
           && httpHeaders.equals(that.httpHeaders)
           && Objects.equals(userAgent, that.userAgent)
-          && Objects.equals(viewType, that.viewType);
+          && Objects.equals(viewType, that.viewType)
+          && Objects.equals(initialBitrate, that.initialBitrate);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(uri, formatHint, httpHeaders, userAgent, viewType);
+      return Objects.hash(uri, formatHint, httpHeaders, userAgent, viewType, initialBitrate);
     }
 
     public static final class Builder {
@@ -286,6 +297,14 @@ public class Messages {
         return this;
       }
 
+      private @Nullable Long initialBitrate;
+
+      @CanIgnoreReturnValue
+      public @NonNull Builder setInitialBitrate(@Nullable Long setterArg) {
+        this.initialBitrate = setterArg;
+        return this;
+      }
+
       public @NonNull CreateMessage build() {
         CreateMessage pigeonReturn = new CreateMessage();
         pigeonReturn.setUri(uri);
@@ -293,18 +312,20 @@ public class Messages {
         pigeonReturn.setHttpHeaders(httpHeaders);
         pigeonReturn.setUserAgent(userAgent);
         pigeonReturn.setViewType(viewType);
+        pigeonReturn.setInitialBitrate(initialBitrate);
         return pigeonReturn;
       }
     }
 
     @NonNull
     ArrayList<Object> toList() {
-      ArrayList<Object> toListResult = new ArrayList<>(5);
+      ArrayList<Object> toListResult = new ArrayList<>(6);
       toListResult.add(uri);
       toListResult.add(formatHint);
       toListResult.add(httpHeaders);
       toListResult.add(userAgent);
       toListResult.add(viewType);
+      toListResult.add(initialBitrate);
       return toListResult;
     }
 
@@ -320,6 +341,8 @@ public class Messages {
       pigeonResult.setUserAgent((String) userAgent);
       Object viewType = pigeonVar_list.get(4);
       pigeonResult.setViewType((PlatformVideoViewType) viewType);
+      Object initialBitrate = pigeonVar_list.get(5);
+      pigeonResult.setInitialBitrate((Long) initialBitrate);
       return pigeonResult;
     }
   }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoAsset.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoAsset.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.media3.common.MediaItem;
+import androidx.media3.datasource.TransferListener;
 import androidx.media3.exoplayer.source.MediaSource;
 import java.util.HashMap;
 import java.util.Map;
@@ -42,7 +43,29 @@ public abstract class VideoAsset {
       @NonNull StreamingFormat streamingFormat,
       @NonNull Map<String, String> httpHeaders,
       @Nullable String userAgent) {
-    return new HttpVideoAsset(remoteUrl, streamingFormat, new HashMap<>(httpHeaders), userAgent);
+    return fromRemoteUrl(remoteUrl, streamingFormat, httpHeaders, userAgent, null);
+  }
+
+  /**
+   * Returns an asset from a remote URL with an optional initial bitrate estimate.
+   *
+   * @param remoteUrl remote asset, i.e. typically beginning with {@code https://} or similar.
+   * @param streamingFormat which streaming format, provided as a hint if able.
+   * @param httpHeaders HTTP headers to set for a request.
+   * @param userAgent optional user agent for HTTP requests.
+   * @param initialBitrate initial bitrate estimate in bits per second, or {@code null} if not
+   *     provided.
+   * @return the asset.
+   */
+  @NonNull
+  static VideoAsset fromRemoteUrl(
+      @Nullable String remoteUrl,
+      @NonNull StreamingFormat streamingFormat,
+      @NonNull Map<String, String> httpHeaders,
+      @Nullable String userAgent,
+      @Nullable Long initialBitrate) {
+    return new HttpVideoAsset(
+        remoteUrl, streamingFormat, new HashMap<>(httpHeaders), userAgent, initialBitrate);
   }
 
   /**
@@ -60,6 +83,8 @@ public abstract class VideoAsset {
   }
 
   @Nullable protected final String assetUrl;
+
+  @Nullable private TransferListener transferListener;
 
   protected VideoAsset(@Nullable String assetUrl) {
     this.assetUrl = assetUrl;
@@ -81,6 +106,22 @@ public abstract class VideoAsset {
    */
   @NonNull
   public abstract MediaSource.Factory getMediaSourceFactory(@NonNull Context context);
+
+  /** Returns an optional initial bitrate estimate in bits per second. */
+  @Nullable
+  public Long getInitialBitrate() {
+    return null;
+  }
+
+  /** Sets the transfer listener that should be attached to network data sources. */
+  public void setTransferListener(@Nullable TransferListener transferListener) {
+    this.transferListener = transferListener;
+  }
+
+  @Nullable
+  protected TransferListener getTransferListener() {
+    return transferListener;
+  }
 
   /** Streaming formats that can be provided to the video player as a hint. */
   enum StreamingFormat {

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -114,7 +114,12 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
         }
       }
       videoAsset =
-          VideoAsset.fromRemoteUrl(uri, streamingFormat, arg.getHttpHeaders(), arg.getUserAgent());
+          VideoAsset.fromRemoteUrl(
+              uri,
+              streamingFormat,
+              arg.getHttpHeaders(),
+              arg.getUserAgent(),
+              arg.getInitialBitrate());
     }
 
     long id;

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/platformview/PlatformViewVideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/platformview/PlatformViewVideoPlayer.java
@@ -10,6 +10,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.media3.common.MediaItem;
 import androidx.media3.exoplayer.ExoPlayer;
+import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter;
 import io.flutter.plugins.videoplayer.ExoPlayerEventListener;
 import io.flutter.plugins.videoplayer.VideoAsset;
 import io.flutter.plugins.videoplayer.VideoPlayer;
@@ -51,9 +52,17 @@ public class PlatformViewVideoPlayer extends VideoPlayer {
         asset.getMediaItem(),
         options,
         () -> {
-          ExoPlayer.Builder builder =
-              new ExoPlayer.Builder(context)
-                  .setMediaSourceFactory(asset.getMediaSourceFactory(context));
+          ExoPlayer.Builder builder = new ExoPlayer.Builder(context);
+          Long initialBitrate = asset.getInitialBitrate();
+          if (initialBitrate != null) {
+            DefaultBandwidthMeter bandwidthMeter =
+                new DefaultBandwidthMeter.Builder(context)
+                    .setInitialBitrateEstimate(initialBitrate)
+                    .build();
+            builder.setBandwidthMeter(bandwidthMeter);
+            asset.setTransferListener(bandwidthMeter);
+          }
+          builder.setMediaSourceFactory(asset.getMediaSourceFactory(context));
           return builder.build();
         });
   }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/texture/TextureVideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/texture/TextureVideoPlayer.java
@@ -12,6 +12,7 @@ import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
 import androidx.media3.common.MediaItem;
 import androidx.media3.exoplayer.ExoPlayer;
+import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter;
 import io.flutter.plugins.videoplayer.ExoPlayerEventListener;
 import io.flutter.plugins.videoplayer.VideoAsset;
 import io.flutter.plugins.videoplayer.VideoPlayer;
@@ -52,9 +53,17 @@ public final class TextureVideoPlayer extends VideoPlayer implements SurfaceProd
         asset.getMediaItem(),
         options,
         () -> {
-          ExoPlayer.Builder builder =
-              new ExoPlayer.Builder(context)
-                  .setMediaSourceFactory(asset.getMediaSourceFactory(context));
+          ExoPlayer.Builder builder = new ExoPlayer.Builder(context);
+          Long initialBitrate = asset.getInitialBitrate();
+          if (initialBitrate != null) {
+            DefaultBandwidthMeter bandwidthMeter =
+                new DefaultBandwidthMeter.Builder(context)
+                    .setInitialBitrateEstimate(initialBitrate)
+                    .build();
+            builder.setBandwidthMeter(bandwidthMeter);
+            asset.setTransferListener(bandwidthMeter);
+          }
+          builder.setMediaSourceFactory(asset.getMediaSourceFactory(context));
           return builder.build();
         });
   }

--- a/packages/video_player/video_player_android/lib/src/android_video_player.dart
+++ b/packages/video_player/video_player_android/lib/src/android_video_player.dart
@@ -106,6 +106,7 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
       userAgent: userAgent,
       formatHint: formatHint,
       viewType: _platformVideoViewTypeFromVideoViewType(options.viewType),
+      initialBitrate: dataSource.initialBitrate,
     );
 
     final int playerId = await _api.create(message);

--- a/packages/video_player/video_player_android/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_android/lib/src/messages.g.dart
@@ -86,6 +86,7 @@ class CreateMessage {
     required this.httpHeaders,
     this.userAgent,
     this.viewType,
+    this.initialBitrate,
   });
 
   String uri;
@@ -98,8 +99,17 @@ class CreateMessage {
 
   PlatformVideoViewType? viewType;
 
+  int? initialBitrate;
+
   List<Object?> _toList() {
-    return <Object?>[uri, formatHint, httpHeaders, userAgent, viewType];
+    return <Object?>[
+      uri,
+      formatHint,
+      httpHeaders,
+      userAgent,
+      viewType,
+      initialBitrate,
+    ];
   }
 
   Object encode() {
@@ -115,6 +125,7 @@ class CreateMessage {
           (result[2] as Map<Object?, Object?>?)!.cast<String, String>(),
       userAgent: result[3] as String?,
       viewType: result[4] as PlatformVideoViewType?,
+      initialBitrate: result[5] as int?,
     );
   }
 

--- a/packages/video_player/video_player_android/pigeons/messages.dart
+++ b/packages/video_player/video_player_android/pigeons/messages.dart
@@ -27,12 +27,13 @@ class PlatformVideoViewCreationParams {
 }
 
 class CreateMessage {
-  CreateMessage({required this.uri, required this.httpHeaders});
+  CreateMessage({required this.uri, required this.httpHeaders, this.initialBitrate});
   String uri;
   PlatformVideoFormat? formatHint;
   Map<String, String> httpHeaders;
   String? userAgent;
   PlatformVideoViewType? viewType;
+  int? initialBitrate;
 }
 
 class PlaybackState {

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -20,7 +20,11 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  video_player_platform_interface: ^6.3.0
+  video_player_platform_interface:
+    git:
+      url: https://github.com/yamacrypt/flutter_packages.git
+      ref: main
+      path: packages/video_player/video_player_platform_interface
 
 dev_dependencies:
   build_runner: ^2.3.3

--- a/packages/video_player/video_player_android/test/android_video_player_test.dart
+++ b/packages/video_player/video_player_android/test/android_video_player_test.dart
@@ -197,6 +197,28 @@ void main() {
       expect(createMessage.userAgent, userAgent);
     });
 
+    test('create with network forwards initial bitrate', () async {
+      final (
+        AndroidVideoPlayer player,
+        MockAndroidVideoPlayerApi api,
+        _,
+      ) = setUpMockPlayer(playerId: 1);
+      when(api.create(any)).thenAnswer((_) async => 2);
+
+      const int initialBitrate = 123456;
+      await player.create(
+        DataSource(
+          sourceType: DataSourceType.network,
+          uri: 'https://example.com',
+          initialBitrate: initialBitrate,
+        ),
+      );
+      final VerificationResult verification = verify(api.create(captureAny));
+      final CreateMessage createMessage =
+          verification.captured[0] as CreateMessage;
+      expect(createMessage.initialBitrate, initialBitrate);
+    });
+
     test('create with file', () async {
       final (
         AndroidVideoPlayer player,

--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,6 +1,15 @@
 ## NEXT
 
+## 2.9.1
+
+* Uses the yamacrypt/flutter_packages Git repository for the platform
+  interface dependency when consumed via git.
+
+## 2.9.0
+
 * Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
+* Adds support for providing an initial HLS bitrate hint when creating
+  players.
 
 ## 2.8.4
 

--- a/packages/video_player/video_player_avfoundation/darwin/RunnerTests/VideoPlayerTests.m
+++ b/packages/video_player/video_player_avfoundation/darwin/RunnerTests/VideoPlayerTests.m
@@ -243,7 +243,8 @@
 
   FVPCreationOptions *create = [FVPCreationOptions
       makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
-      httpHeaders:@{}];
+      httpHeaders:@{}
+      initialBitrate:nil];
   FVPTexturePlayerIds *identifiers = [videoPlayerPlugin createTexturePlayerWithOptions:create
                                                                                  error:&error];
   XCTAssertNil(error);
@@ -275,7 +276,8 @@
   XCTAssertNil(initializationError);
   FVPCreationOptions *create = [FVPCreationOptions
       makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8"
-      httpHeaders:@{}];
+      httpHeaders:@{}
+      initialBitrate:nil];
   FlutterError *createError;
   [videoPlayerPlugin createPlatformViewPlayerWithOptions:create error:&createError];
 
@@ -302,7 +304,8 @@
   XCTAssertNil(initializationError);
   FVPCreationOptions *create = [FVPCreationOptions
       makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8"
-      httpHeaders:@{}];
+      httpHeaders:@{}
+      initialBitrate:nil];
   FlutterError *createError;
   FVPTexturePlayerIds *identifiers =
       [videoPlayerPlugin createTexturePlayerWithOptions:create error:&createError];
@@ -359,7 +362,8 @@
   XCTAssertNil(initializationError);
   FVPCreationOptions *create = [FVPCreationOptions
       makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8"
-      httpHeaders:@{}];
+      httpHeaders:@{}
+      initialBitrate:nil];
   FlutterError *createError;
   FVPTexturePlayerIds *identifiers =
       [videoPlayerPlugin createTexturePlayerWithOptions:create error:&createError];
@@ -405,7 +409,8 @@
   XCTAssertNil(initializationError);
   FVPCreationOptions *create = [FVPCreationOptions
       makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8"
-      httpHeaders:@{}];
+      httpHeaders:@{}
+      initialBitrate:nil];
   FlutterError *createError;
   FVPTexturePlayerIds *identifiers =
       [videoPlayerPlugin createTexturePlayerWithOptions:create error:&createError];
@@ -460,7 +465,8 @@
   XCTAssertNil(initializationError);
   FVPCreationOptions *create = [FVPCreationOptions
       makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/hls/bee.m3u8"
-      httpHeaders:@{}];
+      httpHeaders:@{}
+      initialBitrate:nil];
   FlutterError *createError;
   FVPTexturePlayerIds *identifiers =
       [videoPlayerPlugin createTexturePlayerWithOptions:create error:&createError];
@@ -487,7 +493,8 @@
 
   FVPCreationOptions *create = [FVPCreationOptions
       makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
-      httpHeaders:@{}];
+      httpHeaders:@{}
+      initialBitrate:nil];
   FVPTexturePlayerIds *identifiers = [videoPlayerPlugin createTexturePlayerWithOptions:create
                                                                                  error:&error];
   XCTAssertNil(error);
@@ -516,7 +523,8 @@
 
   FVPCreationOptions *create = [FVPCreationOptions
       makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
-      httpHeaders:@{}];
+      httpHeaders:@{}
+      initialBitrate:nil];
   FVPTexturePlayerIds *identifiers = [videoPlayerPlugin createTexturePlayerWithOptions:create
                                                                                  error:&error];
   XCTAssertNil(error);
@@ -707,7 +715,8 @@
 
     FVPCreationOptions *create = [FVPCreationOptions
         makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
-        httpHeaders:@{}];
+        httpHeaders:@{}
+        initialBitrate:nil];
     FVPTexturePlayerIds *identifiers = [videoPlayerPlugin createTexturePlayerWithOptions:create
                                                                                    error:&error];
     XCTAssertNil(error);
@@ -758,7 +767,8 @@
 
     FVPCreationOptions *create = [FVPCreationOptions
         makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
-        httpHeaders:@{}];
+        httpHeaders:@{}
+        initialBitrate:nil];
     FVPTexturePlayerIds *identifiers = [videoPlayerPlugin createTexturePlayerWithOptions:create
                                                                                    error:&error];
     XCTAssertNil(error);
@@ -822,7 +832,10 @@
 
   [videoPlayerPlugin initialize:&error];
 
-  FVPCreationOptions *create = [FVPCreationOptions makeWithUri:@"" httpHeaders:@{}];
+  FVPCreationOptions *create = [FVPCreationOptions
+      makeWithUri:@""
+      httpHeaders:@{}
+      initialBitrate:nil];
   FVPTexturePlayerIds *identifiers = [videoPlayerPlugin createTexturePlayerWithOptions:create
                                                                                  error:&error];
   FVPVideoPlayer *player = videoPlayerPlugin.playersByIdentifier[@(identifiers.playerId)];
@@ -883,7 +896,8 @@
   XCTAssertNil(error);
   FVPCreationOptions *create = [FVPCreationOptions
       makeWithUri:@"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4"
-      httpHeaders:@{}];
+      httpHeaders:@{}
+      initialBitrate:nil];
   FVPTexturePlayerIds *identifiers = [videoPlayerPlugin createTexturePlayerWithOptions:create
                                                                                  error:&error];
   NSInteger playerIdentifier = identifiers.playerId;

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
@@ -269,7 +269,11 @@ static void upgradeAudioSessionCategory(AVAudioSessionCategory requestedCategory
       headers.count == 0 ? nil : @{@"AVURLAssetHTTPHeaderFieldsKey" : headers};
   AVURLAsset *asset = [AVURLAsset URLAssetWithURL:[NSURL URLWithString:options.uri]
                                           options:itemOptions];
-  return [AVPlayerItem playerItemWithAsset:asset];
+  AVPlayerItem *item = [AVPlayerItem playerItemWithAsset:asset];
+  if (options.initialBitrate != nil) {
+    item.preferredPeakBitRate = options.initialBitrate.doubleValue;
+  }
+  return item;
 }
 
 @end

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/messages.g.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/include/video_player_avfoundation/messages.g.h
@@ -29,9 +29,11 @@ NS_ASSUME_NONNULL_BEGIN
 /// `init` unavailable to enforce nonnull fields, see the `make` class method.
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)makeWithUri:(NSString *)uri
-                httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders;
+                httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders
+             initialBitrate:(nullable NSNumber *)initialBitrate;
 @property(nonatomic, copy) NSString *uri;
 @property(nonatomic, copy) NSDictionary<NSString *, NSString *> *httpHeaders;
+@property(nonatomic, strong, nullable) NSNumber *initialBitrate;
 @end
 
 @interface FVPTexturePlayerIds : NSObject

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/messages.g.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/messages.g.m
@@ -73,16 +73,19 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
 
 @implementation FVPCreationOptions
 + (instancetype)makeWithUri:(NSString *)uri
-                httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders {
+                httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders
+             initialBitrate:(NSNumber *_Nullable)initialBitrate {
   FVPCreationOptions *pigeonResult = [[FVPCreationOptions alloc] init];
   pigeonResult.uri = uri;
   pigeonResult.httpHeaders = httpHeaders;
+  pigeonResult.initialBitrate = initialBitrate;
   return pigeonResult;
 }
 + (FVPCreationOptions *)fromList:(NSArray<id> *)list {
   FVPCreationOptions *pigeonResult = [[FVPCreationOptions alloc] init];
   pigeonResult.uri = GetNullableObjectAtIndex(list, 0);
   pigeonResult.httpHeaders = GetNullableObjectAtIndex(list, 1);
+  pigeonResult.initialBitrate = GetNullableObjectAtIndex(list, 2);
   return pigeonResult;
 }
 + (nullable FVPCreationOptions *)nullableFromList:(NSArray<id> *)list {
@@ -92,6 +95,7 @@ static id GetNullableObjectAtIndex(NSArray<id> *array, NSInteger key) {
   return @[
     self.uri ?: [NSNull null],
     self.httpHeaders ?: [NSNull null],
+    self.initialBitrate ?: [NSNull null],
   ];
 }
 @end

--- a/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
@@ -103,6 +103,7 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
     final CreationOptions pigeonCreationOptions = CreationOptions(
       uri: uri,
       httpHeaders: dataSource.httpHeaders,
+      initialBitrate: dataSource.initialBitrate,
     );
 
     final int playerId;

--- a/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
@@ -74,14 +74,16 @@ class PlatformVideoViewCreationParams {
 }
 
 class CreationOptions {
-  CreationOptions({required this.uri, required this.httpHeaders});
+  CreationOptions({required this.uri, required this.httpHeaders, this.initialBitrate});
 
   String uri;
 
   Map<String, String> httpHeaders;
 
+  int? initialBitrate;
+
   List<Object?> _toList() {
-    return <Object?>[uri, httpHeaders];
+    return <Object?>[uri, httpHeaders, initialBitrate];
   }
 
   Object encode() {
@@ -94,6 +96,7 @@ class CreationOptions {
       uri: result[0]! as String,
       httpHeaders:
           (result[1] as Map<Object?, Object?>?)!.cast<String, String>(),
+      initialBitrate: result[2] as int?,
     );
   }
 

--- a/packages/video_player/video_player_avfoundation/pigeons/messages.dart
+++ b/packages/video_player/video_player_avfoundation/pigeons/messages.dart
@@ -26,10 +26,11 @@ class PlatformVideoViewCreationParams {
 }
 
 class CreationOptions {
-  CreationOptions({required this.uri, required this.httpHeaders});
+  CreationOptions({required this.uri, required this.httpHeaders, this.initialBitrate});
 
   String uri;
   Map<String, String> httpHeaders;
+  int? initialBitrate;
 }
 
 class TexturePlayerIds {

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -24,7 +24,11 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  video_player_platform_interface: ^6.3.0
+  video_player_platform_interface:
+    git:
+      url: https://github.com/yamacrypt/flutter_packages.git
+      ref: main
+      path: packages/video_player/video_player_platform_interface
 
 dev_dependencies:
   build_runner: ^2.3.3

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
@@ -194,6 +194,32 @@ void main() {
       expect(creationOptions.httpHeaders, headers);
     });
 
+    test('create with network forwards initial bitrate', () async {
+      final (
+        AVFoundationVideoPlayer player,
+        MockAVFoundationVideoPlayerApi api,
+        _,
+      ) = setUpMockPlayer(playerId: 1);
+      when(
+        api.createForTextureView(any),
+      ).thenAnswer((_) async => TexturePlayerIds(playerId: 2, textureId: 100));
+
+      const int initialBitrate = 654321;
+      await player.create(
+        DataSource(
+          sourceType: DataSourceType.network,
+          uri: 'https://example.com',
+          initialBitrate: initialBitrate,
+        ),
+      );
+      final VerificationResult verification = verify(
+        api.createForTextureView(captureAny),
+      );
+      final CreationOptions creationOptions =
+          verification.captured[0] as CreationOptions;
+      expect(creationOptions.initialBitrate, initialBitrate);
+    });
+
     test('create with file', () async {
       final (
         AVFoundationVideoPlayer player,

--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## NEXT
 
+## 6.5.0
+
 * Updates minimum supported SDK version to Flutter 3.29/Dart 3.7.
+* Adds an `initialBitrate` option to `DataSource` and `VideoPlayerOptions` for
+  providing adaptive streaming bandwidth hints.
 
 ## 6.4.0
 

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -148,6 +148,7 @@ class DataSource {
     this.asset,
     this.package,
     this.httpHeaders = const <String, String>{},
+    this.initialBitrate,
   });
 
   /// The way in which the video was originally loaded.
@@ -170,6 +171,16 @@ class DataSource {
   /// Only for [DataSourceType.network] videos.
   /// Always empty for other video types.
   Map<String, String> httpHeaders;
+
+  /// Target initial bitrate to use for adaptive streaming, in bits per second.
+  ///
+  /// This is primarily useful for HTTP Live Streaming (HLS) sources to avoid
+  /// starting playback at the lowest bitrate when a more accurate estimate of
+  /// the available bandwidth is known ahead of time.
+  ///
+  /// Only supported on Android and iOS implementations; other platforms will
+  /// silently ignore this value.
+  final int? initialBitrate;
 
   /// The name of the asset. Only set for [DataSourceType.asset] videos.
   final String? asset;
@@ -404,6 +415,7 @@ class VideoPlayerOptions {
     this.mixWithOthers = false,
     this.allowBackgroundPlayback = false,
     this.webOptions,
+    this.initialBitrate,
   });
 
   /// Set this to true to keep playing video in background, when app goes in background.
@@ -419,6 +431,13 @@ class VideoPlayerOptions {
 
   /// Additional web controls
   final VideoPlayerWebOptions? webOptions;
+
+  /// Target initial bitrate to use for adaptive streaming, in bits per second.
+  ///
+  /// This value is forwarded to platform implementations that support
+  /// providing an initial bandwidth estimate when starting playback (currently
+  /// Android and iOS). Other platforms will ignore this value.
+  final int? initialBitrate;
 }
 
 /// [VideoPlayerWebOptions] can be optionally used to set additional web settings

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/video_player/
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 6.4.0
+version: 6.5.0
 
 environment:
   sdk: ^3.7.0

--- a/packages/video_player/video_player_platform_interface/test/video_player_options_test.dart
+++ b/packages/video_player/video_player_platform_interface/test/video_player_options_test.dart
@@ -14,4 +14,8 @@ void main() {
     final VideoPlayerOptions options = VideoPlayerOptions();
     expect(options.mixWithOthers, false);
   });
+  test('VideoPlayerOptions initialBitrate defaults to null', () {
+    final VideoPlayerOptions options = VideoPlayerOptions();
+    expect(options.initialBitrate, isNull);
+  });
 }


### PR DESCRIPTION
## Summary
- reset the video_player package's version to 2.10.0 while keeping the git-sourced federated dependencies
- restore the Android and AVFoundation implementation versions to 2.8.13 and 2.8.4 so that only pubspec.yaml files change in this PR

## Testing
- Not run (Dart SDK unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68cb8a4b9620832caf424145a45fa847